### PR TITLE
Ajout du script mesnotes.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# User config
+local_config.py
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/config.py
+++ b/config.py
@@ -1,0 +1,8 @@
+NETID = ""
+PASSWD = ""
+
+try:
+    from local_config import *
+except ImportError:
+    pass
+

--- a/mesnotes.py
+++ b/mesnotes.py
@@ -118,9 +118,18 @@ class Course:
 
 def print_notes(api_client, inscription):
     courses = map(Course.from_ulb_api, api_client.notes(inscription))
+    passed = inscription.get('grade_annee_reussite', None)
+    if passed == 'Y':
+        passed_string = green(inscription['grade_annee_desc'])
+    elif passed == 'N':
+        passed_string = red(inscription['grade_annee_desc'])
+    else:
+        passed_string = u"en cours"
 
-    print hilight("%s - %s (session %d)" % (
-        inscription['area'], inscription['term_desc'], inscription['session_num']))
+
+    print hilight("%s - %s (session %d) - %s" % (
+        inscription['area'], inscription['term_desc'],
+        inscription['session_num'], passed_string))
     print Course.titles()
     print Course.separator
     print '\n'.join(map(unicode, courses))

--- a/mesnotes.py
+++ b/mesnotes.py
@@ -2,12 +2,11 @@
 # coding: utf-8
 
 from libulb import Client
-from math import sqrt, floor, ceil
-from itertools import chain
 from datetime import datetime
 import config
 
-class options:
+
+class Options:
     color = True
     red = 10
     green = 12
@@ -15,8 +14,9 @@ class options:
     seplines = "-"
     columns = " | "
 
+
 def colorize_text(color, text):
-    if not options.color:
+    if not Options.color:
         return text
     return "\033[%dm%s\033[0m" % (color, text)
 
@@ -27,14 +27,15 @@ blue = lambda txt: colorize_text(34, txt)
 magenta = lambda txt: colorize_text(35, txt)
 hilight = lambda txt: colorize_text(1, txt)
 
+
 class Course:
-    separator = options.sepcolumns.join((
-        options.seplines*10, options.seplines*4, options.seplines*2, 
-        options.seplines*20, options.seplines*52))
+    separator = Options.sepcolumns.join((
+        Options.seplines*10, Options.seplines*4, Options.seplines*2,
+        Options.seplines*20, Options.seplines*52))
 
     @classmethod
-    def titles(klass):
-        return options.columns.join(map(hilight, (
+    def titles(cls):
+        return Options.columns.join(map(hilight, (
             "Mnemonique", "Note", "Cr", "Histogramme".ljust(20), "Nom du cours")))
 
     def __init__(self, mnemonic, name, ects, note=None, lower_note=0, upper_note=None):
@@ -46,17 +47,16 @@ class Course:
         self.upper_note = note if upper_note is None else upper_note
 
     def __unicode__(self):
-        ects_txt = blue("%2d" % int(self.ects))
-        return options.columns.join((
-            self.colorize_mnemonic(), 
-            self.colorize_note(), 
+        return Options.columns.join((
+            self.colorize_mnemonic(),
+            self.colorize_note(),
             self.colorize_ects(),
             self.bar(),
             self.name))
 
     @classmethod
-    def from_ulb_api(klass, api_dict):
-        return klass(
+    def from_ulb_api(cls, api_dict):
+        return cls(
             mnemonic=api_dict['mnemonique'],
             name=api_dict['course_title'],
             ects=int(api_dict['credits']),
@@ -77,9 +77,9 @@ class Course:
             return '----'
         n = round(self.note, 1)
         formatted = "%4s" % n
-        if n < options.red:
+        if n < Options.red:
             return red(formatted)
-        elif n < options.green:
+        elif n < Options.green:
             return yellow(formatted)
         else:
             return green(formatted)
@@ -105,9 +105,9 @@ class Course:
         for i in range((lower), (upper)):
             cur = hilight('*') if i+1 == round(self.note) else '*'
 
-            if i+1 < options.red:
+            if i+1 < Options.red:
                 res += red(cur)
-            elif i+1 < options.green:
+            elif i+1 < Options.green:
                 res += yellow(cur)
             else:
                 res += green(cur)
@@ -115,9 +115,10 @@ class Course:
         res += ' '*(20-int(round(upper)))
         return res
 
+
 def print_notes(api_client, inscription):
     courses = map(Course.from_ulb_api, api_client.notes(inscription))
-    
+
     print hilight("%s - %s (session %d)" % (
         inscription['area'], inscription['term_desc'], inscription['session_num']))
     print Course.titles()
@@ -181,7 +182,7 @@ if __name__ == "__main__":
         help=u"N'affiche pas les résultats en couleur")
     clargs = optparser.parse_args()
 
-    options.color = clargs.color
+    Options.color = clargs.color
     while not clargs.netid:
         clargs.netid = raw_input("NetID ? ")
 

--- a/mesnotes.py
+++ b/mesnotes.py
@@ -130,9 +130,12 @@ def print_notes(api_client, inscription):
         all_ects = sum(x.ects for x in courses)
         all_0 = round(sum(c.default_note(0)*c.ects for c in courses)/all_ects, 1)
         all_20 = round(sum(c.default_note(20)*c.ects for c in courses)/all_ects, 1)
+        description = "Note finale"
+        if all_ects != ects:
+            description += " entre %s et %s" % (str(all_0), str(all_20))
         avg_course = Course(
             mnemonic="Moyenne",
-            name="Note finale entre %s et %s" % (str(all_0), str(all_20)),
+            name=description,
             ects=ects, note=mu,
             lower_note=all_0,
             upper_note=all_20)

--- a/mesnotes.py
+++ b/mesnotes.py
@@ -162,7 +162,7 @@ def print_notes(api_client, inscription):
 
 def main(netid, passwd):
     session = Client.auth(netid, passwd)
-    this_year = datetime.now().year if datetime.now().month >= 9 else datetime.now().year-1
+    this_year = datetime.now().year if datetime.now().month >= 10 else datetime.now().year-1
     this_year_str = '%d%d' % (this_year, (this_year+1)%100)
     for inscr in filter(lambda inscr: inscr['term_code'] == this_year_str, session.inscriptions()):
         print_notes(session, inscr)

--- a/mesnotes.py
+++ b/mesnotes.py
@@ -185,7 +185,7 @@ if __name__ == "__main__":
     while not clargs.netid:
         clargs.netid = raw_input("NetID ? ")
 
-    passwd = config.PASSWD
+    passwd = "" if clargs.netid else config.PASSWD
     while not passwd:
         passwd = getpass()
 

--- a/mesnotes.py
+++ b/mesnotes.py
@@ -1,0 +1,100 @@
+from libulb import Client
+from math import sqrt
+from itertools import chain
+import config
+
+class options:
+    color = True
+    red = 10
+    green = 12
+    sepcolumns = "-+-"
+    seplines = "-"
+    columns = " | "
+
+def colorize_text(color, text):
+    if not options.color:
+        return text
+    return "\033[%dm%s\033[0m" % (color, text)
+
+red = lambda txt: colorize_text(31, txt)
+green = lambda txt: colorize_text(32, txt)
+yellow = lambda txt: colorize_text(33, txt)
+blue = lambda txt: colorize_text(34, txt)
+magenta = lambda txt: colorize_text(35, txt)
+hilight = lambda txt: colorize_text(1, txt)
+
+def colorize_note(note):
+    if note is None:
+        return '----'
+    n = round(note, 1)
+    formatted = "%4s" % n
+    if n < options.red:
+        return red(formatted)
+    elif n < options.green:
+        return yellow(formatted)
+    else:
+        return green(formatted)
+
+def bar(note):
+    if note is None:
+        res = '.' * 20
+    else:
+        res = red('*'*min(int(note), options.red)) +\
+              yellow('*'*min(max(0, int(round(note-options.red))), options.green-options.red)) +\
+              green('*'*min(max(0, int(round(note-options.green))), 20-options.green)) +\
+              ' '*int(round(20-note))
+    return res
+
+def format_course(course):
+    note = course.get('quality_points', None)
+    ects_txt = blue("%2d" % int(course['credits']))
+    return options.columns.join((
+            hilight(yellow(course['mnemonique'])) if note is not None else course['mnemonique'], 
+            colorize_note(note), 
+            hilight(ects_txt) if note is not None and note >= options.red else ects_txt,
+            bar(note),
+            course['course_title']))
+
+def main():
+    session = Client.auth(config.NETID, config.PASSWD)
+    inscriptions = filter(lambda inscr: inscr['term_code'] == '201415', session.inscriptions())
+    all_notes = [x for inscr in inscriptions for x in session.notes(inscr)]
+    notes = filter(lambda x: 'quality_points' in x, all_notes)
+    ects = int(sum(x['credits'] for x in notes))
+
+    mu = sum(x['quality_points']*x['credits'] for x in notes)/ects
+    sigma = sqrt(sum(x['credits']*(x['quality_points']-mu)**2 for x in notes)/(ects-1))
+    dev = 2.53*sigma/sqrt(ects-1)
+
+    favgmin, favgmax = round(mu-dev, 1), round(mu+dev, 1)
+    avgmin, avgmax = int(favgmin), int(favgmax)
+
+    firstline = options.columns.join(map(hilight, (
+        "Mnemonique", "Note", "Cr", "Histogramme".ljust(20), "Nom du cours")))
+
+    lines = map(format_course, all_notes)
+    avgline = options.columns.join((
+        "Moyenne".rjust(10), 
+        colorize_note(mu),
+        magenta("%2d" % ects),
+        ' '*avgmin + '*'*(avgmax-avgmin) + ' '*(20-avgmax),
+        "99%% de chance que la moyenne soit entre %s et %s" % (
+            colorize_note(favgmin), colorize_note(favgmax))))
+
+    s = options.seplines
+    separator = options.sepcolumns.join((s*10, s*4, s*2, s*20, s*52))
+
+    all_ects = sum(x['credits'] for x in all_notes)
+    supositions = []
+
+    for i in [0, 12, 16]:
+        mu = sum(map(lambda x: x['quality_points']*x['credits'] if 'quality_points' in x else i*x['credits'], all_notes))/all_ects
+        supositions.append(options.columns.join((
+            ("Si %d"%i).rjust(10), colorize_note(mu), magenta("%2d"%all_ects), bar(mu), 
+            "Note finale si %d a tous les prochains examens" % i)))
+
+    print
+    print '\n'.join(chain([firstline, separator], lines, [separator, avgline], supositions))
+
+if __name__ == "__main__":
+    main()

--- a/mesnotes.py
+++ b/mesnotes.py
@@ -1,7 +1,11 @@
 from libulb import Client
-from math import sqrt
+from math import sqrt, floor, ceil
 from itertools import chain
+from datetime import datetime
 import config
+
+if not config.NETID or not config.PASSWD:
+    raise Exception("No NETID/PASSWD (edit or create local_config.py")
 
 class options:
     color = True
@@ -23,78 +27,126 @@ blue = lambda txt: colorize_text(34, txt)
 magenta = lambda txt: colorize_text(35, txt)
 hilight = lambda txt: colorize_text(1, txt)
 
-def colorize_note(note):
-    if note is None:
-        return '----'
-    n = round(note, 1)
-    formatted = "%4s" % n
-    if n < options.red:
-        return red(formatted)
-    elif n < options.green:
-        return yellow(formatted)
-    else:
-        return green(formatted)
+class Course:
+    separator = options.sepcolumns.join((
+        options.seplines*10, options.seplines*4, options.seplines*2, 
+        options.seplines*20, options.seplines*52))
+    titles = options.columns.join(map(hilight, (
+        "Mnemonique", "Note", "Cr", "Histogramme".ljust(20), "Nom du cours")))
 
-def bar(note):
-    if note is None:
-        res = '.' * 20
-    else:
-        res = red('*'*min(int(note), options.red)) +\
-              yellow('*'*min(max(0, int(round(note-options.red))), options.green-options.red)) +\
-              green('*'*min(max(0, int(round(note-options.green))), 20-options.green)) +\
-              ' '*int(round(20-note))
-    return res
+    def __init__(self, mnemonic, name, ects, note=None, lower_note=0, upper_note=None):
+        self.mnemonic = mnemonic
+        self.name = name
+        self.ects = ects
+        self.note = note
+        self.lower_note = lower_note
+        self.upper_note = note if upper_note is None else upper_note
 
-def format_course(course):
-    note = course.get('quality_points', None)
-    ects_txt = blue("%2d" % int(course['credits']))
-    return options.columns.join((
-            hilight(yellow(course['mnemonique'])) if note is not None else course['mnemonique'], 
-            colorize_note(note), 
-            hilight(ects_txt) if note is not None and note >= options.red else ects_txt,
-            bar(note),
-            course['course_title']))
+    def __unicode__(self):
+        ects_txt = blue("%2d" % int(self.ects))
+        return options.columns.join((
+            self.colorize_mnemonic(), 
+            self.colorize_note(), 
+            self.colorize_ects(),
+            self.bar(),
+            self.name))
+
+    @classmethod
+    def from_ulb_api(klass, api_dict):
+        return klass(
+            mnemonic=api_dict['mnemonique'],
+            name=api_dict['course_title'],
+            ects=int(api_dict['credits']),
+            note=api_dict.get('quality_points', None))
+
+    def default_note(self, note):
+        return note if self.note is None else self.note
+
+    ### FORMATTERS ###
+    def colorize_mnemonic(self):
+        as_str = self.mnemonic.rjust(10)
+        if self.note is not None:
+            return hilight(yellow(as_str))
+        return as_str
+
+    def colorize_note(self):
+        if self.note is None:
+            return '----'
+        n = round(self.note, 1)
+        formatted = "%4s" % n
+        if n < options.red:
+            return red(formatted)
+        elif n < options.green:
+            return yellow(formatted)
+        else:
+            return green(formatted)
+
+    def colorize_ects(self):
+        as_str = "%2d" % int(self.ects)
+        if self.note is not None:
+            if self.note < 10:
+                return red(as_str)
+            else:
+                return green(as_str)
+        return blue(as_str)
+
+    def bar(self):
+        if self.note is None:
+            return '.'*20
+
+        lower, upper = self.lower_note, self.upper_note
+        if round(lower) == round(upper):
+            lower, upper = int(floor(lower)), int(ceil(upper))
+        else:
+            lower, upper = int(round(lower)), int(round(upper))
+
+        res = ' '*int(round(lower))
+        for i in range((lower), (upper)):
+            cur = hilight('*') if i+1 == round(self.note) else '*'
+
+            if i+1 < options.red:
+                res += red(cur)
+            elif i+1 < options.green:
+                res += yellow(cur)
+            else:
+                res += green(cur)
+
+        res += ' '*(20-int(round(upper)))
+        return res
+
+def print_notes(api_client, inscription):
+    courses = map(Course.from_ulb_api, api_client.notes(inscription))
+    evaluated = filter(lambda c: c.note is not None, courses)
+    
+    print hilight("%s - %s (session %d)" % (
+        inscription['area'], inscription['term_desc'], inscription['session_num']))
+    print Course.titles
+    print Course.separator
+    print '\n'.join(map(unicode, courses))
+
+    if evaluated:
+        ects = sum(x.ects for x in evaluated)
+        mu = sum(x.note*x.ects for x in evaluated)/ects
+        all_ects = sum(x.ects for x in courses)
+        all_0 = round(sum(c.default_note(0)*c.ects for c in courses)/all_ects, 1)
+        all_20 = round(sum(c.default_note(20)*c.ects for c in courses)/all_ects, 1)
+        avg_course = Course(
+            mnemonic="Moyenne",
+            name="Note finale entre %s et %s" % (str(all_0), str(all_20)),
+            ects=ects, note=mu,
+            lower_note=all_0,
+            upper_note=all_20)
+        print Course.separator
+        print unicode(avg_course)
+    print
+
 
 def main():
     session = Client.auth(config.NETID, config.PASSWD)
-    inscriptions = filter(lambda inscr: inscr['term_code'] == '201415', session.inscriptions())
-    all_notes = [x for inscr in inscriptions for x in session.notes(inscr)]
-    notes = filter(lambda x: 'quality_points' in x, all_notes)
-    ects = int(sum(x['credits'] for x in notes))
-
-    mu = sum(x['quality_points']*x['credits'] for x in notes)/ects
-    sigma = sqrt(sum(x['credits']*(x['quality_points']-mu)**2 for x in notes)/(ects-1))
-    dev = 2.53*sigma/sqrt(ects-1)
-
-    favgmin, favgmax = round(mu-dev, 1), round(mu+dev, 1)
-    avgmin, avgmax = int(favgmin), int(favgmax)
-
-    firstline = options.columns.join(map(hilight, (
-        "Mnemonique", "Note", "Cr", "Histogramme".ljust(20), "Nom du cours")))
-
-    lines = map(format_course, all_notes)
-    avgline = options.columns.join((
-        "Moyenne".rjust(10), 
-        colorize_note(mu),
-        magenta("%2d" % ects),
-        ' '*avgmin + '*'*(avgmax-avgmin) + ' '*(20-avgmax),
-        "99%% de chance que la moyenne soit entre %s et %s" % (
-            colorize_note(favgmin), colorize_note(favgmax))))
-
-    s = options.seplines
-    separator = options.sepcolumns.join((s*10, s*4, s*2, s*20, s*52))
-
-    all_ects = sum(x['credits'] for x in all_notes)
-    supositions = []
-
-    for i in [0, 12, 16]:
-        mu = sum(map(lambda x: x['quality_points']*x['credits'] if 'quality_points' in x else i*x['credits'], all_notes))/all_ects
-        supositions.append(options.columns.join((
-            ("Si %d"%i).rjust(10), colorize_note(mu), magenta("%2d"%all_ects), bar(mu), 
-            "Note finale si %d a tous les prochains examens" % i)))
-
-    print
-    print '\n'.join(chain([firstline, separator], lines, [separator, avgline], supositions))
+    this_year = datetime.now().year if datetime.now().month >= 9 else datetime.now().year-1
+    this_year_str = '%d%d' % (this_year, (this_year+1)%100)
+    for inscr in filter(lambda inscr: inscr['term_code'] == this_year_str, session.inscriptions()):
+        print_notes(session, inscr)
 
 if __name__ == "__main__":
     main()

--- a/mesnotes.py
+++ b/mesnotes.py
@@ -185,7 +185,7 @@ if __name__ == "__main__":
     while not clargs.netid:
         clargs.netid = raw_input("NetID ? ")
 
-    passwd = "" if clargs.netid else config.PASSWD
+    passwd = "" if clargs.netid != config.NETID else config.PASSWD
     while not passwd:
         passwd = getpass()
 

--- a/mesnotes.py
+++ b/mesnotes.py
@@ -116,7 +116,6 @@ class Course:
 
 def print_notes(api_client, inscription):
     courses = map(Course.from_ulb_api, api_client.notes(inscription))
-    evaluated = filter(lambda c: c.note is not None, courses)
     
     print hilight("%s - %s (session %d)" % (
         inscription['area'], inscription['term_desc'], inscription['session_num']))
@@ -124,6 +123,7 @@ def print_notes(api_client, inscription):
     print Course.separator
     print '\n'.join(map(unicode, courses))
 
+    evaluated = filter(lambda c: c.note is not None, courses)
     if evaluated:
         ects = sum(x.ects for x in evaluated)
         mu = sum(x.note*x.ects for x in evaluated)/ects
@@ -141,6 +141,17 @@ def print_notes(api_client, inscription):
             upper_note=all_20)
         print Course.separator
         print unicode(avg_course)
+
+    passed = filter(lambda c: c.note and c.note >= 10, courses)
+    if passed:
+        ects = sum(x.ects for x in passed)
+        mu = sum(x.note*x.ects for x in passed)/ects
+        avg_course = Course(
+            mnemonic="Reussis",
+            name="Cours dont la note est >= 10/20",
+            ects=ects, note=mu, lower_note=mu)
+        print unicode(avg_course)
+
     print
 
 

--- a/mesnotes.py
+++ b/mesnotes.py
@@ -94,11 +94,9 @@ class Course:
         if self.note is None:
             return '.'*20
 
-        lower, upper = self.lower_note, self.upper_note
-        if round(lower) == round(upper):
-            lower, upper = int(floor(lower)), int(ceil(upper))
-        else:
-            lower, upper = int(round(lower)), int(round(upper))
+        lower, upper = int(round(self.lower_note)), int(round(self.upper_note))
+        if lower > 0:
+            lower -= 1
 
         res = ' '*int(round(lower))
         for i in range((lower), (upper)):

--- a/mesnotes.py
+++ b/mesnotes.py
@@ -137,7 +137,10 @@ def print_notes(api_client, inscription):
             ects=ects, note=mu,
             lower_note=all_0,
             upper_note=all_20)
-        print Course.separator
+        if evaluated == courses:
+            print hilight(blue(Course.separator))
+        else:
+            print Course.separator
         print unicode(avg_course)
 
     passed = filter(lambda c: c.note and c.note >= 10, courses)


### PR DESCRIPTION
Ajout d'un script pour afficher le relevé de notes. On peut ajouter un fichier de config personnel (`local_config.py`) évitant de retaper son mot de passe à chaque fois (en définissant `NETID = <str>` et `PASSWD = <str>`

```
usage: mesnotes.py [-h] [--netid NETID] [--no-color] [-s SESSION] [-y YEAR]

Points des cours à l'ULB

optional arguments:
  -h, --help            show this help message and exit
  --netid NETID, -n NETID
                        Affiche les points pour ce netid ('' par defaut)
  --no-color, -C        N'affiche pas les résultats en couleur
  -s SESSION, --session SESSION
                        Affiche les points de cette session uniquement
  -y YEAR, --year YEAR  Année à afficher (année du premier quadrimestre)
```
